### PR TITLE
Fix "TypeError: Cannot set property 'border' of undefined"

### DIFF
--- a/struktur.js
+++ b/struktur.js
@@ -349,10 +349,10 @@ function struktur(config = {}) {
                             'text': currentNode.data.trim()
                         };
                         if (this.config.addClass) {
-                            obj.class = currentNode.parentElement.classList.toString();
+                            obj.class = parent.classList.toString();
                         }
                         if (this.config.highlightContent) {
-                            currentNode.style.border = "1px solid rgb(255, 0, 0)";
+                          parent.style.border = "1px solid rgb(255, 0, 0)";
                         }
                         this.parsed.push(obj);
                     }


### PR DESCRIPTION
In this conditional current node is a text node (`nodeType === 3`). It doesn't have style attribute. It's parent has.

**Result**
![image](https://user-images.githubusercontent.com/282605/89036557-8ec99080-d345-11ea-89f2-b6c291311079.png)

Sadly, it considers `People also ask` block structurally similar to organic results.

PS. @NikolaiT have you tried to use ML for data extraction from HTML?